### PR TITLE
Add basic auth to schema registry

### DIFF
--- a/cachedSchemaRegistry.go
+++ b/cachedSchemaRegistry.go
@@ -100,5 +100,5 @@ func (client *CachedSchemaRegistryClient) DeleteVersion(subject string, version 
 
 // SetAuthHeader sets the authentication header for the SchemaRegistryClient
 func (client *CachedSchemaRegistryClient) SetAuthHeader(authHeader fmt.Stringer) error {
-	return client.SetAuthHeader(authHeader)
+	return client.SchemaRegistryClient.SetAuthHeader(authHeader)
 }

--- a/cachedSchemaRegistry.go
+++ b/cachedSchemaRegistry.go
@@ -1,8 +1,10 @@
 package kafka
 
 import (
-	"github.com/linkedin/goavro/v2"
+	"fmt"
 	"sync"
+
+	"github.com/linkedin/goavro/v2"
 )
 
 // CachedSchemaRegistryClient is a schema registry client that will cache some data to improve performance
@@ -94,4 +96,9 @@ func (client *CachedSchemaRegistryClient) DeleteSubject(subject string) error {
 // DeleteVersion deletes the a specific version of a subject, should only be used in development.
 func (client *CachedSchemaRegistryClient) DeleteVersion(subject string, version int) error {
 	return client.SchemaRegistryClient.DeleteVersion(subject, version)
+}
+
+// SetAuthHeader sets the authentication header for the SchemaRegistryClient
+func (client *CachedSchemaRegistryClient) SetAuthHeader(authHeader fmt.Stringer) error {
+	return client.SetAuthHeader(authHeader)
 }

--- a/schemaRegistry.go
+++ b/schemaRegistry.go
@@ -190,7 +190,7 @@ func (client *SchemaRegistryClient) DeleteVersion(subject string, version int) e
 	return err
 }
 
-// BasicAuth sets username and password for HTTP client
+// BasicAuth sets username and password for the SchemaRegistryClient
 func BasicAuth(username, password string) SchemaRegistryClientParam {
 	return func(c *SchemaRegistryClient) error {
 		c.auth = &basicAuth{username: username, password: password}

--- a/schemaRegistry_test.go
+++ b/schemaRegistry_test.go
@@ -3,12 +3,13 @@ package kafka
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/linkedin/goavro/v2"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/linkedin/goavro/v2"
 )
 
 type TestObject struct {
@@ -124,5 +125,51 @@ func TestSchemaRegistryClient_Error(t *testing.T) {
 	expectedErr := Error{500, "Error in the backend datastore"}
 	if err.Error() != expectedErr.Error() {
 		t.Errorf("Expected error to be %s, got %s", expectedErr.Error(), err.Error())
+	}
+}
+
+var flagtests = []struct {
+	basicAuth *basicAuth
+}{
+	{&basicAuth{"test", "password"}},
+	{nil},
+}
+
+func TestSchemaRegistryClient_BasicAuth(t *testing.T) {
+
+	response := []string{"test"}
+
+	for _, tt := range flagtests {
+		t.Logf("%v", tt.basicAuth)
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if tt.basicAuth != nil {
+				if r.Header.Get("Authorization") != tt.basicAuth.String() {
+					t.Errorf("No Authorization header found, expected: %s", tt.basicAuth)
+				}
+			} else {
+				if r.Header.Get("Authorization") != "" {
+					t.Error("Authorization header found, expected None")
+				}
+			}
+
+			w.Header().Set("Content-Type", contentType)
+			str, _ := json.Marshal(response)
+			fmt.Fprintf(w, string(str))
+		}))
+
+		SchemaRegistryClient := NewSchemaRegistryClient([]string{mockServer.URL})
+		if tt.basicAuth != nil {
+			err := BasicAuth(tt.basicAuth.username, tt.basicAuth.password)(SchemaRegistryClient)
+			if err != nil {
+				t.Errorf("Found error %s", err)
+			}
+		}
+		subjects, err := SchemaRegistryClient.GetSubjects()
+		if err != nil {
+			t.Errorf("Found error %s", err)
+		}
+		if !reflect.DeepEqual(subjects, response) {
+			t.Errorf("Subjects did not match expected %s, got %s", response, subjects)
+		}
 	}
 }


### PR DESCRIPTION
This PR adds the capability to use HTTP basic authentication to connect to the schema registry.

An example of a client using this code would be:
```
var schemaRegistryClient schema.SchemaRegistryClientInterface
schemaRegistryClient = schema.NewCachedSchemaRegistryClient([]string{*registry})

if *registryBasicAuth != "" {
  username := *registryUser
  password := *registryPassword
  schema.BasicAuth(registryUser, registryPassword)(schemaRegistryClient)
}
```