### PR TITLE
Update avroProducer.go

### DIFF
--- a/avroProducer.go
+++ b/avroProducer.go
@@ -42,6 +42,9 @@ func (ap *AvroProducer) GetSchemaId(topic string, avroCodec *goavro.Codec) (int,
 
 func (ap *AvroProducer) Add(topic string, schema string, key []byte, value []byte) error {
 	avroCodec, err := goavro.NewCodec(schema)
+	if err != nil {
+		return err
+	}
 	schemaId, err := ap.GetSchemaId(topic, avroCodec)
 	if err != nil {
 		return err


### PR DESCRIPTION
avro codec error was not checked, when it was nil it was still used and led to segmentation faults in ap.GetSchemaId call